### PR TITLE
Update infinityFree.ino

### DIFF
--- a/examples/infinityFree/infinityFree.ino
+++ b/examples/infinityFree/infinityFree.ino
@@ -55,7 +55,7 @@ void setup()
 
 	/* getting abc vars */
 	int loc = payload.indexOf("var a=toNumbers(");
-	String temp = payload.substring(loc, temp.length());
+	String temp = payload.substring(loc, loc+147);
 	temp.replace("var a=toNumbers(\"", "");
 	String a = temp.substring(0, 32);
 


### PR DESCRIPTION
Fixed bug on Arduino UNO.
`String temp = payload.substring(loc, temp.length());` won't work as expected. Because the second parameter of `substring` on arduino is **the index to end the substring before**, instead of **length of the substring**.
See also [substring usage](https://www.arduino.cc/reference/en/language/variables/data-types/string/functions/substring/)